### PR TITLE
Fix NRE while attempt to construct with bytes

### DIFF
--- a/RenderWareIo/BinaryIplFile.cs
+++ b/RenderWareIo/BinaryIplFile.cs
@@ -24,7 +24,7 @@ namespace RenderWareIo
         {
             this.stream = new MemoryStream(data);
 
-            this.BinaryIpl = BinaryIpl.Read(this.stream);
+            this.BinaryIpl = (new BinaryIpl()).Read(this.stream);
             this.stream.Close();
         }
 

--- a/RenderWareIo/ImgFile.cs
+++ b/RenderWareIo/ImgFile.cs
@@ -25,7 +25,7 @@ namespace RenderWareIo
         {
             this.stream = new MemoryStream(data);
 
-            this.Img = Img.Read(this.stream);
+            this.Img = (new Img()).Read(this.stream);
             this.stream.Close();
         }
 

--- a/RenderWareIo/TxdFile.cs
+++ b/RenderWareIo/TxdFile.cs
@@ -21,8 +21,7 @@ namespace RenderWareIo
         public TxdFile(byte[] data)
         {
             this.stream = new MemoryStream(data);
-
-            this.Txd = Txd.Read(this.stream);
+            this.Txd = (new Txd()).Read(this.stream);
             this.stream.Close();
         }
 


### PR DESCRIPTION
This PR fix null reference exception while attempt to construct TxdFile, ImgFile and BinaryIplFile using bytes instead of file path.

This is an PR for issue #1 